### PR TITLE
Include licenses for lineedit and prompt_toolkit.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.md
+include lineedit/deps/LICENSE


### PR DESCRIPTION
Both MIT and BSD require the file be included when distributed.

xref: https://github.com/randy3k/radian/issues/244